### PR TITLE
ISSUE-2-Refresh state when transferring/purging

### DIFF
--- a/src/models/QueueItem.ts
+++ b/src/models/QueueItem.ts
@@ -55,16 +55,19 @@ export class QueueItem extends SbDependencyBase implements IInteractableItem {
   }
 
   transfer = async (provider: ServiceBusProvider) => {
+    this.setLoading(provider)
     await service.transferQueueDl(this.connectionString, this.label)
     await this.refresh(provider)
   }
 
   purge = async (provider: ServiceBusProvider) => {
+    this.setLoading(provider)
     await service.purgeQueueMessages(this.connectionString, this.label)
     await this.refresh(provider)
   }
 
   purgeDl = async (provider: ServiceBusProvider) => {
+    this.setLoading(provider)
     await service.purgeQueueDeadLetter(this.connectionString, this.label)
     await this.refresh(provider)
   }

--- a/src/models/SubscriptionItem.ts
+++ b/src/models/SubscriptionItem.ts
@@ -56,16 +56,19 @@ export class SubscriptionItem extends SbDependencyBase implements IInteractableI
   }
 
   transfer = async (provider: ServiceBusProvider) => {
+    this.setLoading(provider)
     await service.transferSubscriptionDl(this.connectionString, this.topicName, this.label)
     await this.refresh(provider)
   }
 
   purge = async (provider: ServiceBusProvider) => {
+    this.setLoading(provider)
     await service.purgeSubscriptionMessages(this.connectionString, this.topicName, this.label)
     await this.refresh(provider)
   }
 
   purgeDl = async (provider: ServiceBusProvider) => {
+    this.setLoading(provider)
     await service.purgeSubscriptionDeadletter(this.connectionString, this.topicName, this.label)
     await this.refresh(provider)
   }


### PR DESCRIPTION
Add refresh state at the start of transfer/purge action.

Fix bug in transfer logic which caused a "infinite" loop. Fixed by first receiving all messages on DL, then transferring back to main queue.

Fixes #2 